### PR TITLE
refactor: URI의 단어들을 복수 명사로 수정하여 Restful API 규칙 적용

### DIFF
--- a/pybo/urls.py
+++ b/pybo/urls.py
@@ -16,74 +16,74 @@ urlpatterns = [
     path("", page_views.index, name="index"),
     path("<int:question_id>/", page_views.detail, name="detail"),
     # question_views.py
-    path("question/create/", question_views.question_create, name="question_create"),
+    path("questions/create/", question_views.question_create, name="question_create"),
     path(
-        "question/modify/<int:question_id>/",
+        "questions/modify/<int:question_id>/",
         question_views.question_modify,
         name="question_modify",
     ),
     path(
-        "question/delete/<int:question_id>/",
+        "questions/delete/<int:question_id>/",
         question_views.question_delete,
         name="question_delete",
     ),
     # answer_views.py
     path(
-        "answer/create/<int:question_id>/",
+        "answers/create/<int:question_id>/",
         answer_views.answer_create,
         name="answer_create",
     ),
     path(
-        "answer/modify/<int:answer_id>/",
+        "answers/modify/<int:answer_id>/",
         answer_views.answer_modify,
         name="answer_modify",
     ),
     path(
-        "answer/delete/<int:answer_id>/",
+        "answers/delete/<int:answer_id>/",
         answer_views.answer_delete,
         name="answer_delete",
     ),
     # comment_question_view.py
     path(
-        "comment/create/question/<int:question_id>/",
+        "comments/create/questions/<int:question_id>/",
         comment_question_view.comment_create_question,
         name="comment_create_question",
     ),
     path(
-        "comment/modify/question/<int:comment_id>/",
+        "comments/modify/questions/<int:comment_id>/",
         comment_question_view.comment_modify_question,
         name="comment_modify_question",
     ),
     path(
-        "comment/delete/question/<int:comment_id>/",
+        "comments/delete/questions/<int:comment_id>/",
         comment_question_view.comment_delete_question,
         name="comment_delete_question",
     ),
     # comment_answer_view.py
     path(
-        "comment/create/answer/<int:answer_id>/",
+        "comments/create/answers/<int:answer_id>/",
         comment_answer_view.comment_create_answer,
         name="comment_create_answer",
     ),
     path(
-        "comment/modify/answer/<int:comment_id>/",
+        "comments/modify/answers/<int:comment_id>/",
         comment_answer_view.comment_modify_answer,
         name="comment_modify_answer",
     ),
     path(
-        "comment/delete/answer/<int:comment_id>/",
+        "comments/delete/answers/<int:comment_id>/",
         comment_answer_view.comment_delete_answer,
         name="comment_delete_answer",
     ),
     # vote_views.py
     path(
-        "vote/question/<int:question_id>/",
+        "vote/questions/<int:question_id>/",
         vote_views.vote_question,
         name="vote_question",
     ),
-    path("vote/answer/<int:answer_id>/", vote_views.vote_answer, name="vote_answer"),
+    path("vote/answers/<int:answer_id>/", vote_views.vote_answer, name="vote_answer"),
     path(
-        "vote/comment/<int:comment_id>/",
+        "vote/comments/<int:comment_id>/",
         vote_views.vote_comment,
         name="vote_comment",
     ),


### PR DESCRIPTION
RESTful한 API를 구현하기 위해 지켜야할 URI 규칙들 중에서 URI의 단어들을 복수 명사를 사용하는 것을 권하고 있습니다.
이는 Microsoft 홈페이지에 명시되어 있습니다.

[MicroSoft RESTful web API design](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)
> Adopt a consistent naming convention in URIs. In general, it helps to use plural nouns for URIs that reference collections.

따라서 이 PR에서는 uri의 단어들을 복수명사로 수정하였습니다.

단, vote의 경우 동사의 의미로 사용하는 것에 가까워서 votes로 수정하지 않았습니다. 